### PR TITLE
FIXED: Mocha "compilers" parameter deprecation

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
---compilers ts-node/register
+--require ts-node/register
 --require source-map-support/register
 --recursive
 --full-trace


### PR DESCRIPTION
FIXED: Using the `require` parameter instead of `compilers` for Mocha because that will be deprecated. See issue #17.