### PR TITLE
Update NodeJs in cI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "node"
 
 before_install:
-  - npm install -g npm@6
   - npm install -g serverless
   - npm install -g greenkeeper-lockfile@1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 node_js:
   - "lts/*"
-  - "8"
+  - "node"
 
 before_install:
   - npm install -g npm@6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.0.0]
+
+- BREAKING CHANGE: Dropping support for NodeJS v6, CI pipelines are running on the current LTS version (now 10.15.0) and the latest version available on the CI platform. This change enables keeping third-party dependencies up-to-date.
+
 ## [1.0.2]
 
 - The `aws-sdk` dependency is updated to `^2.312.0`.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,11 @@
 environment:
   matrix:
-    - nodejs_version: '8'
-    - nodejs_version: '6'
+    - nodejs_version: 'LTS'
+    - nodejs_version: 'Current'
 
 install:
+  - node --version
+  - npm --version
   - ps: Install-Product node $env:nodejs_version
   - set CI=true
   - npm install --global npm@latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-typescript",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "A sample to create AWS Lambda functions in TypeScript with Serverless.",
   "main": "handler.js",
   "scripts": {


### PR DESCRIPTION
Run CI on the latest and the LTS node releases both in Travis and AppVeyor.